### PR TITLE
fix: go-test migration to new release

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -5,12 +5,13 @@ on:
     types: [ opened, synchronize, reopened ]
 permissions:
   contents: read
+  pull-requests: write
+  packages: write
 jobs:
   test:
-    uses: netcracker/qubership-core-infra/.github/workflows/go-build-with-sonar.yaml@b9ddd544e3b5b17a31866d34c220b14e76681f31 #v1.3.0
+    uses: Netcracker/qubership-core-infra/.github/workflows/generic-go-build.yaml@bc2a0bd082147e23b4091616c608a21cc2957728 # v2.4.1
     with:
-      actor: ${{ github.actor }}
       sonar-project-key: ${{ vars.SONAR_PROJECT_KEY }}
       go-module-dir: '.'
-    secrets:
-      sonar-token: ${{ secrets.SONAR_TOKEN }}
+      skip-docker: true
+    secrets: inherit


### PR DESCRIPTION
Migrate go-test workflow to new release version