### PR TITLE
fix(build): pin Go builder Alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine3.24@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df AS builder
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
## Why

Renovate treats the generic `-alpine` suffix as a compatibility constraint, so it updates Go without moving the Alpine release line.

## What

Use the explicit `alpine3.24` suffix for the existing Go builder. The version and digest are unchanged, so the selected image bytes do not change. The shared Renovate preset can now update Go and Alpine together.

Related shared configuration: https://github.com/Netcracker/renovate-config/pull/41

## How to verify

The Dockerfile resolves the existing multi-architecture digest through the explicit Alpine 3.24 tag, and Dockerfile validation reports no warnings.
